### PR TITLE
Shifting to using chrome in selenium tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 mysite/.env
 *.pyc
-
-service/tests/chromedrivers

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 mysite/.env
 *.pyc
+
+service/tests/chromedrivers

--- a/service/tests/chromedrivers/.gitignore
+++ b/service/tests/chromedrivers/.gitignore
@@ -1,0 +1,3 @@
+# Ignore everything in this directory
+*
+!.gitignore

--- a/service/tests/test_setup_teardown/selenium_test_setup.py
+++ b/service/tests/test_setup_teardown/selenium_test_setup.py
@@ -1,8 +1,8 @@
 import os
 
-import selenium.webdriver
 from django.conf import settings
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from selenium import webdriver
 from selenium.webdriver.firefox.webdriver import WebDriver
 
 
@@ -20,8 +20,8 @@ def get_sauce_driver(capabilities):
     capabilities['tags'] = [os.environ['TRAVIS_PYTHON_VERSION'], 'CI']
     capabilities['browserName'] = 'firefox'
 
-    return selenium.webdriver.Remote(desired_capabilities=capabilities,
-                                     command_executor="http://{0}/wd/hub".format(hub_url))
+    return webdriver.Remote(desired_capabilities=capabilities,
+                            command_executor="http://{0}/wd/hub".format(hub_url))
 
 
 def get_local_driver():
@@ -29,7 +29,9 @@ def get_local_driver():
     Returns local web driver
     :return:
     """
-    return WebDriver()
+    if 'TRAVIS' in os.environ:
+        return WebDriver()
+    return webdriver.Chrome(settings.BASE_DIR + '/service/tests/chromedrivers/chromedriver_mac64')
 
 
 class SeleniumTests(StaticLiveServerTestCase):
@@ -37,6 +39,7 @@ class SeleniumTests(StaticLiveServerTestCase):
     Base setup and tear down for integration tests.
     Distribute into different files if integration tests grow.
     """
+
     @classmethod
     def setUpClass(cls):
         super(SeleniumTests, cls).setUpClass()

--- a/service/tests/test_setup_teardown/selenium_test_setup.py
+++ b/service/tests/test_setup_teardown/selenium_test_setup.py
@@ -31,7 +31,11 @@ def get_local_driver():
     """
     if 'TRAVIS' in os.environ:
         return WebDriver()
-    return webdriver.Chrome(settings.BASE_DIR + '/service/tests/chromedrivers/chromedriver_mac64')
+    chromedriver_path = settings.BASE_DIR + '/service/tests/chromedrivers/chromedriver'
+    if os.path.isfile(chromedriver_path):
+        return webdriver.Chrome(chromedriver_path)
+    else:
+        raise FileNotFoundError("Chromedriver not found. Place file or link in {0}".format(chromedriver_path))
 
 
 class SeleniumTests(StaticLiveServerTestCase):


### PR DESCRIPTION
Moving from firefox webdrivers to chrome webdrivers for development tests only.
Travis tests will still continue to run on firefox.
To set up selenium tests in dev environment the user will have to download chromedriver and place them in the chromedrivers folder under tests.
https://sites.google.com/a/chromium.org/chromedriver/downloads
